### PR TITLE
Repository class store implementation and some other minor enhancements on basic repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,34 @@ This type of repository will pull a remote archive relative to the `haibu-server
 }
 ```
 
+#### npm
+
+This type of repository will install a npm package as application. The package will be available as directory under its name and the scripts will be installed in the `.bin` directory.
+So scripts.start should have one of both as relative directory:
+
+```json
+"scripts": {
+  "start": ".bin/server.js"
+}
+```
+
+or:
+
+```json
+"scripts": {
+  "start": "name of npm package/server.js"
+}
+```
+
+```json
+{
+  "repository": {
+    "type": "npm",
+    "package": "name of npm package"
+  }
+}
+```
+
 ## Run Tests
 All of the `haibu` tests are written in [vows][0], and cover all of the use cases described above.
 <pre>

--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -31,6 +31,8 @@ Spawner.prototype.trySpawn = function (app, callback) {
   var self = this, 
       repo = app instanceof haibu.repository.Repository ? app : haibu.repository.create(app);
       
+  if (repo instanceof Error) return callback(repo);
+   
   repo.bootstrap(function (err, existed) {
     if (err) {
       return callback(err);

--- a/lib/haibu/repositories/git.js
+++ b/lib/haibu/repositories/git.js
@@ -19,12 +19,24 @@ var inherits = require('util').inherits,
 // for cloning, and updating Git repositories.
 //
 var Git = exports.Git = function (app, options) {
-  Npm.call(this, app, options);
+  return Npm.call(this, app, options);
 };
 
 // Inherit from the Npm repository.
 inherits(Git, Npm); 
   
+// 
+// ### function validate ()
+// #### @keys {Array||String} The keys to check in app. (i.e. 'scripts.start')
+// #### @app {Object} (optional) The app object to check. if not given this.app will be used. 
+// #### @return {Error|| undefined} undefined if valid, Error if not
+// Checks Application configuration attributes used by this repository type
+//
+Git.prototype.validate = function (keys, app) {
+  keys = keys || [];
+  return Npm.prototype.validate.call(this, keys.concat('repository.url'), app);
+}
+
 //
 // ### function init (callback) 
 // #### @callback {function} Continuation to respond to.
@@ -42,12 +54,12 @@ Git.prototype.init = function (callback) {
     });
   }
     
-    haibu.emit('git:clone', 'info', { 
-    url: self.app.repository.url, 
-    dir: self.appDir, 
-    app: self.app.name,
+  haibu.emit('git:clone', 'info', { 
     type: 'git',
-    username: self.app.user
+    user: self.app.user,
+    name: self.app.name,
+    from: self.app.repository.url,
+    to: self.appDir
   });
 
   // TODO (indexzero): Validate the security of this regular expression since it is on the command line.

--- a/lib/haibu/repositories/git.js
+++ b/lib/haibu/repositories/git.js
@@ -5,7 +5,7 @@
  *
  */
 
-var sys = require('sys'), 
+var inherits = require('util').inherits, 
     path = require('path'),
     exec = require('child_process').exec,
     haibu = require('../../haibu'),
@@ -23,7 +23,7 @@ var Git = exports.Git = function (app, options) {
 };
 
 // Inherit from the Npm repository.
-sys.inherits(Git, Npm); 
+inherits(Git, Npm); 
   
 //
 // ### function init (callback) 

--- a/lib/haibu/repositories/git.js
+++ b/lib/haibu/repositories/git.js
@@ -9,7 +9,7 @@ var inherits = require('util').inherits,
     path = require('path'),
     exec = require('child_process').exec,
     haibu = require('../../haibu'),
-    Npm = require('./npm').Npm;
+    Repository = require('./repository').Repository;
 
 //
 // ### function Git (app, options)
@@ -19,11 +19,11 @@ var inherits = require('util').inherits,
 // for cloning, and updating Git repositories.
 //
 var Git = exports.Git = function (app, options) {
-  return Npm.call(this, app, options);
+  return Repository.call(this, app, options);
 };
 
-// Inherit from the Npm repository.
-inherits(Git, Npm); 
+// Inherit from Repository
+inherits(Git, Repository); 
   
 // 
 // ### function validate ()
@@ -34,7 +34,7 @@ inherits(Git, Npm);
 //
 Git.prototype.validate = function (keys, app) {
   keys = keys || [];
-  return Npm.prototype.validate.call(this, keys.concat('repository.url'), app);
+  return Repository.prototype.validate.call(this, keys.concat('repository.url'), app);
 }
 
 //
@@ -110,60 +110,5 @@ Git.prototype.init = function (callback) {
     });
   }
 
-  executeUntilEmpty();
-};
-
-//
-// ### function update (callback) 
-// #### @callback {function} Continuation to respond to.
-// Updates the git repository associated with the application
-// and this instance. Checks out the specific branch in `app.repository.branch`
-// if it exists, then updates git submodules. Updates npm dependencies
-// through calling `self.installDependencies`.
-//
-Git.prototype.update = function (callback) {
-  var self = this, commands = [
-    'cd ' + this.appDir + '/' + this.app.directories.home + ' && git pull ' + this.app.repository.url + ' ' + this.app.repository.branch || 'master',
-    'cd ' + this.appDir + '/' + this.app.directories.home + ' && git submodule update'
-  ];
-  
-  haibu.emit('git:update', 'info', { 
-    url: self.app.repository.url, 
-    dir: [self.appDir, this.app.directories.home].join('/'), 
-    app: self.app.name,
-    type: 'git',
-    username: self.app.user
-  });
-  
-  function executeUntilEmpty() {
-    var command = commands.shift();
-    
-    // Remark: Using 'exec' here because chaining 'spawn' is not effective here
-    exec(command, function (err, stdout, stderr) {
-      if (err !== null) {
-        haibu.emit('git:update', 'error', { 
-          url: self.app.repository.url, 
-          dir: [self.appDir, self.app.directories.home].join('/'), 
-          app: self.app.name,
-          error: err.message,
-          command: command, 
-          type: 'git',
-          username: self.app.user
-        });
-        
-        callback(err, false);
-      }
-      else if (commands.length > 0) {
-        executeUntilEmpty();
-      }
-      else if (commands.length === 0) {
-        self.installDependencies(function () {
-          // Ignore errors right now
-          callback(null, true);
-        });
-      }
-    });
-  }
-  
   executeUntilEmpty();
 };

--- a/lib/haibu/repositories/git.js
+++ b/lib/haibu/repositories/git.js
@@ -49,7 +49,7 @@ Git.prototype.init = function (callback) {
   var self = this;
   
   function installNpm () {
-    self.installDependencies(function (err, installed, packages) {
+    self.installDependencies(function (err, packages) {
       return err ? callback(err) : callback(null, true, packages);
     });
   }

--- a/lib/haibu/repositories/index.js
+++ b/lib/haibu/repositories/index.js
@@ -19,6 +19,7 @@ var repos = {
       tar: require('./tar').Tar,
       zip: require('./zip').Zip,
       local: require('./local-file').LocalFile,
+      npm: require('./npm').Npm
     };
 
 //

--- a/lib/haibu/repositories/index.js
+++ b/lib/haibu/repositories/index.js
@@ -34,7 +34,7 @@ exports.create = function (app, options) {
   //
   var validate = exports.validate(app), factory, type;
   if (!validate.valid) {
-    throw new Error(JSON.stringify(validate.errors));
+    return new Error(JSON.stringify(validate.errors));
   }
   
   type = (typeof(app.repository.type) == 'string') ? app.repository.type.toLowerCase() : '';

--- a/lib/haibu/repositories/index.js
+++ b/lib/haibu/repositories/index.js
@@ -5,18 +5,21 @@
  *
  */
 
-var Git = require('./git').Git,
-    Npm = require('./npm').Npm,
-    Tar = require('./tar').Tar,
-    Zip = require('./zip').Zip,
-    LocalFile = require('./local-file').LocalFile,
-    haibu = require('../../haibu');
+var haibu = require('../../haibu');
 
 //
 // ### Export Components
 // Export relevant components of the repositories module
 //
 exports.Repository = require('./repository').Repository;
+
+// Fill repos store with known repository types
+var repos = {
+      git: require('./git').Git,
+      tar: require('./tar').Tar,
+      zip: require('./zip').Zip,
+      local: require('./local-file').LocalFile,
+    };
 
 //
 // ### function create (app, options)
@@ -34,33 +37,50 @@ exports.create = function (app, options) {
     throw new Error(JSON.stringify(validate.errors));
   }
   
-  factory = {
-    git: function () {
-      return new Git(app, options);
-    },
-    npm: function () {
-      return new Npm(app, options);
-    },
-    tar: function () {
-      return new Tar(app, options);
-    },
-    zip: function () {
-      return new Zip(app, options);
-    },
-    local: function () {
-      return new LocalFile(app, options);
-    }
-  };
-  
-  type = app.repository.type.toLowerCase();
-  if (factory[type]) {
+  type = (typeof(app.repository.type) == 'string') ? app.repository.type.toLowerCase() : '';
+  if (repos[type]) {
     haibu.emit('repository:create', 'info', { type: type, app: app.name, user: app.user });
-    return factory[type]();
+    return new repos[type](app, options);
   }
   else {
-    throw new Error('Cannot create repository for unknown type ' + type);
+    return new Error('Cannot create repository for unknown type ' + type);
   }
 };
+
+//
+// ### function add (name, class)
+// #### @name {String} Name of the repository to add
+// #### @constructor {Function} Constructor of the repository instance to create
+// Adds a new repository constructor to the repository list
+//
+exports.add = function (name, constructor) {
+  if (!repos[name]) {
+    repos[name] = constructor;
+  } else {
+    return new Error('A repository type with this name (' + name + ') already exists!');
+  }
+}
+
+//
+// ### function remove (name)
+// #### @name {String} Name of the repository to remove
+// Removes a repository constructor from the repository list
+//
+exports.remove = function (name) {
+  if (repos[name]) {
+    delete repos[name];
+  } else {
+    return new Error('A repository type with this name (' + name + ') does not exists!');
+  }
+}
+
+//
+// ### function list ()
+// Lists all repository types names in the repository list. Returns array of names.
+//
+exports.list = function () {
+  return Object.keys(repos);
+}
 
 //
 // ### function validatePackage (pkg)

--- a/lib/haibu/repositories/index.js
+++ b/lib/haibu/repositories/index.js
@@ -32,9 +32,9 @@ exports.create = function (app, options) {
   //
   // Perform validation on app before we attempt to create a repository 
   //
-  var validate = exports.validate(app), factory, type;
-  if (!validate.valid) {
-    return new Error(JSON.stringify(validate.errors));
+  var invalid = exports.validate(app), type;
+  if (invalid) {
+    return invalid;
   }
   
   type = (typeof(app.repository.type) == 'string') ? app.repository.type.toLowerCase() : '';
@@ -83,41 +83,10 @@ exports.list = function () {
 }
 
 //
-// ### function validatePackage (pkg)
+// ### function validate (pkg)
 // #### @pkg {Object} The package.json manifest to validate
 // Validates the package.json manifest for the basic haibu usage.
 //
 exports.validate = function (pkg) {
-  function invalid (prop) {
-    return {
-      errors: {
-        property: prop,
-        message: 'Property ' + prop + ' is required'
-      }
-    };
-  }
-  
-  //
-  // Check for the basic required properties needed for haibu 
-  //
-  var i, required = ['name', 'user', 'repository', 'scripts'];
-  for (i = 0; i < required.length; i++) {
-    if (!pkg[required[i]]) {
-      return invalid(required[i]);
-    }
-  }
-  
-  // Check for repository.type
-  if (!pkg.repository.type) {
-    return invalid('repository.type');
-  }
-  
-  // Check for scripts.start  
-  if (!pkg.scripts.start) {
-    return invalid('scripts.start');
-  }
-  
-  return {
-    valid: true
-  };
+  return exports.Repository.prototype.validate([], pkg);
 };

--- a/lib/haibu/repositories/local-file.js
+++ b/lib/haibu/repositories/local-file.js
@@ -85,7 +85,7 @@ LocalFile.prototype.init = function (callback) {
           return callback(err);
         }
 
-        self.installDependencies(function (err, installed, packages) {
+        self.installDependencies(function (err, packages) {
           if (err) {
             return callback(err);
           }

--- a/lib/haibu/repositories/local-file.js
+++ b/lib/haibu/repositories/local-file.js
@@ -20,7 +20,8 @@ var inherits = require('util').inherits,
 // loading applications from a location on the local filesystem.
 //
 var LocalFile = exports.LocalFile = function (app, options) {
-  Npm.call(this, app, options);
+  var invalid = Npm.call(this, app, options);
+  if (invalid) return invalid;
 
   options = options || {};
   this.packageDir = options.packageDir || haibu.config.get('directories:packages');
@@ -29,58 +30,74 @@ var LocalFile = exports.LocalFile = function (app, options) {
 // Inherit from Npm Repository
 inherits(LocalFile, Npm);
 
+// 
+// ### function validate ()
+// #### @keys {Array||String} The keys to check in app. (i.e. 'scripts.start')
+// #### @app {Object} (optional) The app object to check. if not given this.app will be used. 
+// #### @return {Error|| undefined} undefined if valid, Error if not
+// Checks Application configuration attributes used by this repository type
+//
+LocalFile.prototype.validate = function (keys, app) {
+  keys = keys || [];
+  return Npm.prototype.validate.call(this, keys.concat('repository.directory'), app);
+}
+
 //
 // ### function fetch (callback)
 // #### @callback {function} Continuation to pass control back to when complete.
-// Checks to see if the app associated with this instance has the requisite properties
-// and that the associated directories exist.
+// Checks to see if the app repo directorie exist and if so copies it to the appDir.
 //
 LocalFile.prototype.fetch = function (callback) {
-  // Ensure that a valid app was passed into the constructor
-  if (this.app && this.app.repository && this.app.repository.directory) {
-    var appDir = this.app.repository.directory;
-    fs.stat(appDir, function (err) {
-      callback(err, appDir);
+  var self = this,
+      repoDir = this.app.repository.directory;
+
+  fs.stat(repoDir, function (err) {
+    if (err) {
+      return callback(err);
+    }
+
+    exec('cp -r ' + repoDir + ' ' + self.appDir, function (err) {
+      callback(err, repoDir);
     });
-  } 
-  else {
-    callback(new Error("'app.repository.directory' not specified"));
-  }
+  });
 };
 
 //
 // ### function init (callback)
 // #### @callback {function} Continuation to pass control back to when complete.
-// Initializes this instance by checking the app, then installing
-// npm dependencies, then copying the files located in `app.repository.directory`
-// to the target directory set on `this.appDir`
+// Initializes this instance by checking the app, then copying the files located in
+// `app.repository.directory` to the target directory set on `this.appDir`, then
+// installing npm dependencies.
 //
 LocalFile.prototype.init = function (callback) {
   var self = this;
+
+  haibu.emit('local:clone', 'info', { 
+    type: 'local',
+    user: self.app.user,
+    name: self.app.name,
+    from: self.app.repository.directory, 
+    to: self.appDir
+  });
+
   this.fetch(function (err, localDirectory) {
     if (err) {
       return callback(err);
     }
-    
+
     self._setHome(path.basename(localDirectory));
     self.installDependencies(function (err, installed, packages) {
       if (err) {
         return callback(err);
       }
-      
-      exec('cp -r ' + localDirectory + ' ' + self.appDir, function (err) {
-        if (err) {
-          return callback(err);
+
+      self.stat(function (statErr, exists) {
+        if (statErr) {
+          return callback(statErr);
         }
 
-        self.stat(function (statErr, exists) {
-          if (statErr) {
-            return callback(statErr);
-          }
-
-          fs.readdir(self.appDir, function () {
-            callback(null, true, packages);
-          });
+        fs.readdir(self.appDir, function () {
+          callback(null, true, packages);
         });
       });
     });

--- a/lib/haibu/repositories/local-file.js
+++ b/lib/haibu/repositories/local-file.js
@@ -5,7 +5,7 @@
  *
  */
 
-var sys = require('sys'),
+var inherits = require('util').inherits,
     fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
@@ -27,7 +27,7 @@ var LocalFile = exports.LocalFile = function (app, options) {
 };
 
 // Inherit from Npm Repository
-sys.inherits(LocalFile, Npm);
+inherits(LocalFile, Npm);
 
 //
 // ### function fetch (callback)

--- a/lib/haibu/repositories/local-file.js
+++ b/lib/haibu/repositories/local-file.js
@@ -10,7 +10,7 @@ var inherits = require('util').inherits,
     path = require('path'),
     exec = require('child_process').exec,
     haibu = require('../../haibu'),
-    Npm = require('./npm').Npm;
+    Repository = require('./repository').Repository;
 
 //
 // ### function LocalFile (app, options)
@@ -20,15 +20,15 @@ var inherits = require('util').inherits,
 // loading applications from a location on the local filesystem.
 //
 var LocalFile = exports.LocalFile = function (app, options) {
-  var invalid = Npm.call(this, app, options);
+  var invalid = Repository.call(this, app, options);
   if (invalid) return invalid;
 
   options = options || {};
   this.packageDir = options.packageDir || haibu.config.get('directories:packages');
 };
 
-// Inherit from Npm Repository
-inherits(LocalFile, Npm);
+// Inherit from Repository
+inherits(LocalFile, Repository);
 
 // 
 // ### function validate ()
@@ -39,26 +39,20 @@ inherits(LocalFile, Npm);
 //
 LocalFile.prototype.validate = function (keys, app) {
   keys = keys || [];
-  return Npm.prototype.validate.call(this, keys.concat('repository.directory'), app);
+  return Repository.prototype.validate.call(this, keys.concat('repository.directory'), app);
 }
 
 //
 // ### function fetch (callback)
 // #### @callback {function} Continuation to pass control back to when complete.
-// Checks to see if the app repo directorie exist and if so copies it to the appDir.
+// Checks to see if the app repo directorie exist.
 //
 LocalFile.prototype.fetch = function (callback) {
   var self = this,
       repoDir = this.app.repository.directory;
 
   fs.stat(repoDir, function (err) {
-    if (err) {
-      return callback(err);
-    }
-
-    exec('cp -r ' + repoDir + ' ' + self.appDir, function (err) {
-      callback(err, repoDir);
-    });
+    callback(err, repoDir);
   });
 };
 
@@ -85,18 +79,17 @@ LocalFile.prototype.init = function (callback) {
       return callback(err);
     }
 
-    self._setHome(path.basename(localDirectory));
-    self.installDependencies(function (err, installed, packages) {
-      if (err) {
-        return callback(err);
-      }
-
-      self.stat(function (statErr, exists) {
-        if (statErr) {
-          return callback(statErr);
+    exec('cp -r ' + localDirectory + ' ' + self.appDir, function (err) {
+      self.stat(function (err, exists) {
+        if (err) {
+          return callback(err);
         }
 
-        fs.readdir(self.appDir, function () {
+        self.installDependencies(function (err, installed, packages) {
+          if (err) {
+            return callback(err);
+          }
+
           callback(null, true, packages);
         });
       });

--- a/lib/haibu/repositories/npm.js
+++ b/lib/haibu/repositories/npm.js
@@ -17,10 +17,10 @@ var inherits = require('util').inherits,
 // Constructor function for the Npm repository. 
 //
 var Npm = exports.Npm = function (app, options) {
-  options = options || {};
-  Repository.call(this, app, options);  
+  return Repository.call(this, app, options);  
 };
 
+// Inherit from Repository.
 inherits(Npm, Repository);
 
 //

--- a/lib/haibu/repositories/npm.js
+++ b/lib/haibu/repositories/npm.js
@@ -5,7 +5,7 @@
  *
  */
 
-var sys = require('sys'),
+var inherits = require('util').inherits,
     fs = require('fs'),
     haibu = require('../../haibu'),
     Repository = require('./repository').Repository;
@@ -21,7 +21,7 @@ var Npm = exports.Npm = function (app, options) {
   Repository.call(this, app, options);  
 };
 
-sys.inherits(Npm, Repository);
+inherits(Npm, Repository);
 
 //
 // ### function exists (callback)

--- a/lib/haibu/repositories/npm.js
+++ b/lib/haibu/repositories/npm.js
@@ -23,48 +23,39 @@ var Npm = exports.Npm = function (app, options) {
 // Inherit from Repository.
 inherits(Npm, Repository);
 
+// 
+// ### function validate ()
+// #### @keys {Array||String} The keys to check in app. (i.e. 'scripts.start')
+// #### @app {Object} (optional) The app object to check. if not given this.app will be used. 
+// #### @return {Error|| undefined} undefined if valid, Error if not
+// Checks Application configuration attributes used by this repository type
 //
-// ### function exists (callback)
-// #### @callback {function} Continuation to pass control back to when complete.
-// Checks to see if the `appDir` on this instance exists on the file system.
-//
-Npm.prototype.exists = function (callback) {
-  fs.stat(this.appDir, function (err, stats) {
-    return err ? callback(err, false) : callback(null, false);
-  });
-};
+Npm.prototype.validate = function (keys, app) {
+  keys = keys || [];
+  return Repository.prototype.validate.call(this, keys.concat('repository.package'), app);
+}
 
 //
-// ### function installDependencies (callback)
+// ### function init (callback)
 // #### @callback {function} Continuation to pass control back to when complete.
-// Installs the required npm dependencies for the app associated 
-// with this repository instance on this system.
+// Installs the given `app.repository.package` with NPM to the appDir directory.
+// REMARK: the application will be installed in this.homeDir + app.repository.package
+// If the package has bin scripts they are installed by NPM in this.homeDir + '.bin'
 //
-Npm.prototype.installDependencies = function (callback) {
-  haibu.utils.npm.install(this.homeDir, this.app, callback);
-};
-
-//
-// ### function allDependencies (callback)
-// #### @callback {function} Continuation to pass control back to when complete.
-// Gets the all of the dependencies for the app that this repository instance manages. 
-//
-Npm.prototype.allDependencies = function (callback) {
-  haibu.utils.npm.list(this.homeDir, this.app, callback);
-};
-
-//
-// ### function init / update (callback)
-// #### @callback {function} Continuation to pass control back to when complete.
-// Lightweight wrapper to `installDependencies` for consistency with other 
-// Repository objects.
-//
-Npm.prototype.init = Npm.prototype.update = function (callback) {
-  this.installDependencies(function (err, dependencies) {
+Npm.prototype.init = function (callback) {
+  var self = this;
+  // fetch app from npm repository + install dependencies
+  haibu.utils.npm.install(this.appDir, [this.app.repository.package], function (err, dependencies) {
     if (err) {
       return callback(err);
     }
     
-    callback(null, true, dependencies);
-  });
+    self.stat(function (err, exists) {
+      if (err) {
+        return callback(err);
+      }
+        
+      callback(null, true, dependencies);
+	})
+  })
 };

--- a/lib/haibu/repositories/remote-file.js
+++ b/lib/haibu/repositories/remote-file.js
@@ -26,26 +26,31 @@ var inherits = require('util').inherits,
 // * Cloudfiles
 //
 var RemoteFile = exports.RemoteFile = function (app, options) {
-  Npm.call(this, app, options);
+  var invalid = Npm.call(this, app, options);
+  if (invalid) return invalid;
   
   options = options || {};
   this.packageDir = options.packageDir || haibu.config.get('directories:packages');
-
-  if (app.repository.protocol === 'cloudfiles') {
-    if (!app.repository.auth) {
-      throw new Error('Cannot create CloudFiles backed RemoteFile repository without auth');
-    }
-    
-    this.client = cloudfiles.createClient({ auth: app.repository.auth }); 
-
-    // Configure cloudfiles to make it's local cache directory
-    // the same as haibu's packages directory 
-    this.client.config.cache.path = this.packageDir;
-  }
 };
 
 // Inherit from the Npm Repository
 inherits(RemoteFile, Npm);
+
+// 
+// ### function validate ()
+// #### @keys {Array||String} The keys to check in app. (i.e. 'scripts.start')
+// #### @app {Object} (optional) The app object to check. if not given this.app will be used. 
+// #### @return {Error|| undefined} undefined if valid, Error if not
+// Checks Application configuration attributes used by this repository type
+//
+RemoteFile.prototype.validate = function (keys, app) {
+  var test = (app.protocol && app.protocol === 'cloudfiles')
+       ? ['repository.auth', 'repository.container', 'repository.filename']
+       : ['repository.url'];
+  keys = keys || [];
+  
+  return Npm.prototype.validate.call(this, keys.concat('repository.protocol', test), app);
+}
 
 //
 // ### function fetch (callback)
@@ -81,6 +86,13 @@ RemoteFile.prototype.fetch = function (callback) {
 //
 RemoteFile.prototype.fetchCloudfiles = function (options, callback) {
   var self = this;
+  
+  this.client = cloudfiles.createClient({ auth: this.app.repository.auth }); 
+
+  // Configure cloudfiles to make it's local cache directory
+  // the same as haibu's packages directory 
+  this.client.config.cache.path = this.packageDir;
+	
   this.client.setAuth(function () {
     self.client.getFile(options.container, options.filename, function (err, file) {
       if (err) {

--- a/lib/haibu/repositories/remote-file.js
+++ b/lib/haibu/repositories/remote-file.js
@@ -12,7 +12,7 @@ var inherits = require('util').inherits,
     request = require('request'),
     cloudfiles = require('cloudfiles'),
     haibu = require('../../haibu'),
-    Npm = require('./npm').Npm;
+    Repository = require('./repository').Repository;
 
 //
 // ### function RemoteFile (app, options)
@@ -26,15 +26,15 @@ var inherits = require('util').inherits,
 // * Cloudfiles
 //
 var RemoteFile = exports.RemoteFile = function (app, options) {
-  var invalid = Npm.call(this, app, options);
+  var invalid = Repository.call(this, app, options);
   if (invalid) return invalid;
   
   options = options || {};
   this.packageDir = options.packageDir || haibu.config.get('directories:packages');
 };
 
-// Inherit from the Npm Repository
-inherits(RemoteFile, Npm);
+// Inherit from Repository
+inherits(RemoteFile, Repository);
 
 // 
 // ### function validate ()
@@ -49,7 +49,7 @@ RemoteFile.prototype.validate = function (keys, app) {
        : ['repository.url'];
   keys = keys || [];
   
-  return Npm.prototype.validate.call(this, keys.concat('repository.protocol', test), app);
+  return Repository.prototype.validate.call(this, keys.concat('repository.protocol', test), app);
 }
 
 //
@@ -92,7 +92,7 @@ RemoteFile.prototype.fetchCloudfiles = function (options, callback) {
   // Configure cloudfiles to make it's local cache directory
   // the same as haibu's packages directory 
   this.client.config.cache.path = this.packageDir;
-	
+
   this.client.setAuth(function () {
     self.client.getFile(options.container, options.filename, function (err, file) {
       if (err) {

--- a/lib/haibu/repositories/remote-file.js
+++ b/lib/haibu/repositories/remote-file.js
@@ -5,7 +5,7 @@
  *
  */
 
-var sys = require('sys'),
+var inherits = require('util').inherits,
     fs = require('fs'),
     path = require('path'),
     url = require('url'),
@@ -45,7 +45,7 @@ var RemoteFile = exports.RemoteFile = function (app, options) {
 };
 
 // Inherit from the Npm Repository
-sys.inherits(RemoteFile, Npm);
+inherits(RemoteFile, Npm);
 
 //
 // ### function fetch (callback)

--- a/lib/haibu/repositories/repository.js
+++ b/lib/haibu/repositories/repository.js
@@ -68,7 +68,24 @@ Repository.prototype.validate = function (keys, app) {
 // with this repository instance on this system.
 //
 Repository.prototype.installDependencies = function (callback) {
-  haibu.utils.npm.install(this.homeDir, this.app, callback);
+  var homeDir = this.homeDir;
+  
+  if (!this.app.dependencies) {
+    fs.readFile(path.join(homeDir, 'package.json'), function (err, data) {
+      var pkg = {};
+      if (err) return callback(err);
+
+      try {
+        pkg = JSON.parse(data);
+      } catch (err) {
+        return callback(err);
+      }
+
+      haibu.utils.npm.install(homeDir, pkg, callback);
+    });
+  } else {
+    haibu.utils.npm.install(homeDir, this.app, callback);
+  }
 };
 
 //

--- a/lib/haibu/repositories/repository.js
+++ b/lib/haibu/repositories/repository.js
@@ -18,6 +18,10 @@ var fs = require('fs'),
 // `repositories` module.
 //
 var Repository = exports.Repository = function (app, options) {
+  // checks all properties of this.app recursively through all child classes of Repository
+  var invalid = this.validate([], app);
+  if (invalid) return invalid;
+  
   options = options || {};
   
   this.app = app;
@@ -25,6 +29,43 @@ var Repository = exports.Repository = function (app, options) {
   this.appsDir = options.appsDir || haibu.config.get('directories:apps');
 };
 
+//
+// ### function validate ()
+// #### @keys {Array||String} The keys to check in app. (i.e. 'scripts.start')
+// #### @app {Object} (optional) The app object to check. if not given this.app will be used. 
+// #### @return {Error|| undefined} undefined if valid, Error if not
+// Checks Application configuration attributes used by this repository type
+//
+Repository.prototype.validate = function (keys, app) {
+  var i, i2, required, props, check; 
+  
+  // Check for the basic required properties needed for haibu repositories + requested ones 
+  keys = keys || [];
+  required = ['name', 'user', 'repository.type', 'scripts.start'].concat(keys);
+  
+  for (i = 0; i < required.length; i++) {
+    // split property if needed and run over each part
+    props = required[i].split('.');
+    check = app || this.app;
+
+    for (i2 = 0; i2 < props.length; i2++) {
+      if (typeof(check[props[i2]]) == 'undefined') {
+        haibu.emit('repo:validate', 'warn', 'Property ' + required[i] +
+          ' is required in Application configuration!', check);
+        return new Error('Property ' + required[i] + ' is required!');
+      }
+      check = check[props[i2]];
+    }
+  }
+  // all ok!  
+  return
+}
+
+//
+// ### function stat (callback)
+// #### @callback {function} Continuation to pass control back to when complete.
+// Check if there is only one directory in the appDir path
+//
 Repository.prototype.stat = function (callback) {
   var self = this;
   

--- a/lib/haibu/repositories/repository.js
+++ b/lib/haibu/repositories/repository.js
@@ -62,6 +62,16 @@ Repository.prototype.validate = function (keys, app) {
 }
 
 //
+// ### function installDependencies (callback)
+// #### @callback {function} Continuation to pass control back to when complete.
+// Installs the required npm dependencies for the app associated 
+// with this repository instance on this system.
+//
+Repository.prototype.installDependencies = function (callback) {
+  haibu.utils.npm.install(this.homeDir, this.app, callback);
+};
+
+//
 // ### function stat (callback)
 // #### @callback {function} Continuation to pass control back to when complete.
 // Check if there is only one directory in the appDir path
@@ -195,7 +205,7 @@ Repository.prototype.__defineGetter__('appDir', function () {
 // that this repository instance manages.
 //
 Repository.prototype.__defineGetter__('homeDir', function () {
-  if (!this.app.directories || !this.app.directories.home) {
+  if (!this.app.directories || typeof this.app.directories.home == 'undefined') {
     return null;
   }
   

--- a/lib/haibu/repositories/tar.js
+++ b/lib/haibu/repositories/tar.js
@@ -54,7 +54,7 @@ Tar.prototype.init = function (callback) {
           return callback(err);
         }
         
-        self.installDependencies(function (err, installed, packages) {
+        self.installDependencies(function (err, packages) {
           if (err) {
             return callback(err);
           }

--- a/lib/haibu/repositories/tar.js
+++ b/lib/haibu/repositories/tar.js
@@ -5,7 +5,7 @@
  *
  */
  
-var sys = require('sys'),
+var inherits = require('util').inherits,
     exec = require('child_process').exec,
     RemoteFile = require('./remote-file').RemoteFile;
 
@@ -20,7 +20,7 @@ var Tar = exports.Tar = function (app, options) {
 };
 
 // Inherit from RemoteFile repository
-sys.inherits(Tar, RemoteFile);
+inherits(Tar, RemoteFile);
 
 //
 // ### function init (callback)

--- a/lib/haibu/repositories/tar.js
+++ b/lib/haibu/repositories/tar.js
@@ -7,6 +7,7 @@
  
 var inherits = require('util').inherits,
     exec = require('child_process').exec,
+    haibu = require('../../haibu'),
     RemoteFile = require('./remote-file').RemoteFile;
 
 //
@@ -16,10 +17,10 @@ var inherits = require('util').inherits,
 // Constructor function for the Tar repository. 
 //
 var Tar = exports.Tar = function (app, options) {
-  RemoteFile.call(this, app, options);
+  return RemoteFile.call(this, app, options);
 };
 
-// Inherit from RemoteFile repository
+// Inherit from the RemoteFile repository
 inherits(Tar, RemoteFile);
 
 //
@@ -31,6 +32,16 @@ inherits(Tar, RemoteFile);
 //
 Tar.prototype.init = function (callback) {
   var self = this;  
+
+  haibu.emit('tar:get', 'info', { 
+    type: 'tar',
+    user: self.app.user,
+    name: self.app.name,
+    protocol: self.app.repository.protocol,
+    from: self.app.repository.url, 
+    to: self.appDir
+  });
+
   this.fetch(function (err, packageFile) {
     if (err) {
       return callback(err);

--- a/lib/haibu/repositories/zip.js
+++ b/lib/haibu/repositories/zip.js
@@ -7,6 +7,7 @@
 
 var inherits = require('util').inherits,
     exec = require('child_process').exec,
+    haibu = require('../../haibu'),
     RemoteFile = require('./remote-file').RemoteFile;
 
 //
@@ -15,8 +16,8 @@ var inherits = require('util').inherits,
 // #### @options {Object} Options to pass along to the repository
 // Constructor function for the Zip repository. 
 //
-var Zip = function (app, options) {
-  RemoteFile.call(this, app, options);
+var Zip = exports.Zip = function (app, options) {
+  return RemoteFile.call(this, app, options);
 };
 
 // Inherit from the RemoteFile repository
@@ -31,6 +32,16 @@ inherits(Zip, RemoteFile);
 //
 Zip.prototype.init = function (callback) {
   var self = this;    
+
+  haibu.emit('tar:get', 'info', { 
+    type: 'tar',
+    user: self.app.user,
+    name: self.app.name,
+    protocol: self.app.repository.protocol,
+    from: self.app.repository.url, 
+    to: self.appDir
+  });
+
   this.fetch(function (err, packageFile) {
     if (err) {
       return callback(err);
@@ -58,5 +69,3 @@ Zip.prototype.init = function (callback) {
     });
   });
 };
-
-exports.Zip = Zip;

--- a/lib/haibu/repositories/zip.js
+++ b/lib/haibu/repositories/zip.js
@@ -5,7 +5,7 @@
  *
  */
 
-var sys = require('sys'),
+var inherits = require('util').inherits,
     exec = require('child_process').exec,
     RemoteFile = require('./remote-file').RemoteFile;
 
@@ -20,7 +20,7 @@ var Zip = function (app, options) {
 };
 
 // Inherit from the RemoteFile repository
-sys.inherits(Zip, RemoteFile);
+inherits(Zip, RemoteFile);
 
 //
 // ### function init (callback)

--- a/lib/haibu/repositories/zip.js
+++ b/lib/haibu/repositories/zip.js
@@ -54,7 +54,7 @@ Zip.prototype.init = function (callback) {
           return callback(err);
         }
 
-        self.installDependencies(function (err, installed, packages) {
+        self.installDependencies(function (err, packages) {
           if (err) {
             return callback(err);
           }

--- a/lib/haibu/utils/npm.js
+++ b/lib/haibu/utils/npm.js
@@ -118,7 +118,7 @@ exports.install = function (dir, target, callback) {
         return callback(err);
       }
       else if (dependencies === true) {
-        return callback(null, true, []);
+        return callback(null, []);
       }
       
       meta = {

--- a/test/fixtures/repositories/local-file-dependencies/package.json
+++ b/test/fixtures/repositories/local-file-dependencies/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "local-file",
+  "description": "this application attempts to break out of the chroot and do nasty things to your server",
+  "version": "0.1.0",
+  "author": "Elijah Insua",
+  "dependencies": {
+    "color": "x.x.x"
+  },
+  "engine": [ "node >=0.1.90" ]
+}

--- a/test/fixtures/repositories/local-file-dependencies/run.js
+++ b/test/fixtures/repositories/local-file-dependencies/run.js
@@ -1,0 +1,10 @@
+var fs = require("fs");
+
+try {
+  fs.readFileSync("/etc/passwd");
+  process.exit(0);
+} 
+catch (e) {
+  console.log(e);
+  process.exit(-1)
+}

--- a/test/plugins/chroot-test.js
+++ b/test/plugins/chroot-test.js
@@ -106,19 +106,6 @@ vows.describe('haibu/plugins/chroot').addBatch(
   "An instance of the Npm repository": {
     "the allDependencies() method": {
       topic: function () {
-        repo.allDependencies(this.callback);
-      },
-      "should list the installed dependencies from the chrooted directory": function (err, deps) {
-        assert.isNull(err);
-        assert.isArray(deps);
-        assert.include(deps, 'express');
-      }
-    }
-  }
-}).addBatch({
-  "An instance of the Npm repository": {
-    "the allDependencies() method": {
-      topic: function () {
         var that = this;
         new (haibu.drone.Drone)().clean(npmApp, function (err) {
           if (err) {

--- a/test/repositories/core-test.js
+++ b/test/repositories/core-test.js
@@ -1,0 +1,110 @@
+/*
+ * store-test.js: Tests for the repository store.
+ *
+ * (C) 2010, Nodejitsu Inc.
+ *
+ */
+
+var assert = require('assert'),
+    path = require('path'),
+    eyes = require('eyes'),
+    vows = require('vows'),
+    helpers = require('../helpers'),
+    haibu = require('../../lib/haibu');
+
+var ipAddress = '127.0.0.1',
+    port = 9000,
+    app = {
+      "name": "test",
+      "user": "marak",
+      "repository": {
+        "type": "create",
+        "url": "https://github.com/Marak/hellonode.git",
+      },
+      "scripts": {
+        "start": "server.js"
+      }
+    },
+    appMalformed = {
+    };
+
+var called = false; 
+
+function newRepo(app, options) {
+  called = true;
+};
+
+vows.describe('haibu/repositories/core').addBatch(
+  helpers.requireInit()
+).addBatch({
+  "When using haibu, ": {
+    "get the haibu.repository module": {
+      topic: function () {
+        return haibu.repository;
+      },
+      "should have store functions": function (repo) {
+        assert.isObject(repo);
+        assert.isFunction(repo.create);
+        assert.isFunction(repo.add);
+        assert.isFunction(repo.remove);
+        assert.isFunction(repo.list);
+      },
+      "executing the add() method": {
+        topic: function (repo) {
+          this.callback(repo.add('test', newRepo));
+        },
+        "should add a new repo type": function (err) {
+        },
+        "with existing repository type": {
+          topic: function (repo) {
+            this.callback(null, repo.add('test', newRepo));
+          },
+          "should return an Error object": function (err, repoTest) {
+              assert.instanceOf(repoTest, Error);
+          }
+        }
+      },
+      "executing the list() method": {
+        topic: function (repo) {
+          return repo.list();
+        },
+        "should list all repo types": function (list) {
+          assert.isArray(list);
+          assert.include(list, 'git');
+          assert.include(list, 'tar');
+          assert.include(list, 'zip');
+          assert.include(list, 'local');
+        }
+      },
+      "executing the remove() method": {
+        topic: function (repo) {
+          repo.add('test2', newRepo);
+          if (repo.remove('test2')) return false;
+          return repo.list();
+        },
+        "should remove a repo type": function (list) {
+            assert.isArray(list);
+            assert.equal(list.indexOf('test2'), -1);
+        }
+      },
+      "executing the create() method": {
+        topic: function (repo) {
+          repo.add('create', newRepo);
+          return repo.create(app, {});
+        },
+        "should return a repo instance": function (newRepo) {
+            assert.isTrue(called);
+        },
+        "with a malformed app definition": {
+          topic: function (newRepo, repo) {
+            called = false;
+            return repo.create(appMalformed, {});
+          },
+          "should return an Error object": function (err, repoTest) {
+              assert.instanceOf(repoTest, Error);
+          }
+        }
+      }
+    }
+  }
+}).export(module);

--- a/test/repositories/core-test.js
+++ b/test/repositories/core-test.js
@@ -7,14 +7,11 @@
 
 var assert = require('assert'),
     path = require('path'),
-    eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
     haibu = require('../../lib/haibu');
 
-var ipAddress = '127.0.0.1',
-    port = 9000,
-    app = {
+var app = {
       "name": "test",
       "user": "marak",
       "repository": {

--- a/test/repositories/git-test.js
+++ b/test/repositories/git-test.js
@@ -7,6 +7,7 @@
 
 var assert = require('assert'),
     path = require('path'),
+    exec = require('child_process').exec,
     eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
@@ -43,6 +44,19 @@ vows.describe('haibu/repositories/git').addBatch(
         assert.isFunction(git.init);
         assert.isFunction(git.exists);
         assert.isFunction(git.update);
+      },
+      "the init() method": {
+        topic: function (git) {
+          var self = this;
+          exec('rm -rf ' + path.join(git.appDir, '*'), function(err) {
+            if (err) self.callback(err);
+            git.init(self.callback);
+          });
+        },
+        "should install to the specified location": function (err, success, files) {
+          assert.isNull(err);
+          assert.isArray(files);
+        }
       }
     }
   }

--- a/test/repositories/git-test.js
+++ b/test/repositories/git-test.js
@@ -49,8 +49,10 @@ vows.describe('haibu/repositories/git').addBatch(
         topic: function (git) {
           var self = this;
           exec('rm -rf ' + path.join(git.appDir, '*'), function(err) {
-            if (err) self.callback(err);
-            git.init(self.callback);
+            git.mkdir(function (err, created) {
+              if (err) self.callback(err);
+              git.init(self.callback);
+            });
           });
         },
         "should install to the specified location": function (err, success, files) {

--- a/test/repositories/git-test.js
+++ b/test/repositories/git-test.js
@@ -39,7 +39,7 @@ vows.describe('haibu/repositories/git').addBatch(
         return haibu.repository.create(app);
       },
       "should be a valid repository": function (git) {
-        assert.equal(haibu.repository.validate(git.app).valid, true);
+        assert.instanceOf(git, haibu.repository.Repository);
         assert.isFunction(git.init);
         assert.isFunction(git.exists);
         assert.isFunction(git.update);

--- a/test/repositories/git-test.js
+++ b/test/repositories/git-test.js
@@ -8,19 +8,13 @@
 var assert = require('assert'),
     path = require('path'),
     exec = require('child_process').exec,
-    eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
     haibu = require('../../lib/haibu');
 
-var ipAddress = '127.0.0.1',
-    port = 9000,
-    app = {
+var app = {
       "name": "test",
       "user": "marak",
-      "directories": {
-        "home": "hellonode"
-      },
       "repository": {
         "type": "git",
         "url": "https://github.com/Marak/hellonode.git",
@@ -34,7 +28,7 @@ var ipAddress = '127.0.0.1',
 vows.describe('haibu/repositories/git').addBatch(
   helpers.requireInit()
 ).addBatch({
-  "When using haibu": {
+  "When using haibu,": {
     "an instance of the Git repository": {
       topic: function () {
         return haibu.repository.create(app);
@@ -42,18 +36,17 @@ vows.describe('haibu/repositories/git').addBatch(
       "should be a valid repository": function (git) {
         assert.instanceOf(git, haibu.repository.Repository);
         assert.isFunction(git.init);
-        assert.isFunction(git.exists);
-        assert.isFunction(git.update);
       },
       "the init() method": {
         topic: function (git) {
           var self = this;
+          if (!(git instanceof haibu.repository.Repository)) return git;
           exec('rm -rf ' + path.join(git.appDir, '*'), function(err) {
             git.mkdir(function (err, created) {
               if (err) self.callback(err);
               git.init(self.callback);
-            });
-          });
+            })
+          })
         },
         "should install to the specified location": function (err, success, files) {
           assert.isNull(err);

--- a/test/repositories/local-file-test.js
+++ b/test/repositories/local-file-test.js
@@ -73,8 +73,10 @@ vows.describe('haibu/repositories/local-file').addBatch(helpers.requireInit()).a
         topic: function (localFile) {
           var self = this;
           exec('rm -rf ' + path.join(localFile.appDir, '*'), function(err) {
-            if (err) self.callback(err);
-            localFile.init(self.callback);
+            localFile.mkdir(function (err, created) {
+              if (err) self.callback(err);
+              localFile.init(self.callback);
+            });
           });
         },
         "should install to the specified location": function (err, success, files) {

--- a/test/repositories/local-file-test.js
+++ b/test/repositories/local-file-test.js
@@ -9,19 +9,13 @@ var assert = require('assert'),
     fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
-    eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
     haibu = require('../../lib/haibu');
 
-var ipAddress = '127.0.0.1', 
-    port = 9000, 
-    app = {
+var app = {
        "name": "test",
        "user": "marak",
-       "directories": {
-         "home": "hellonode"
-       },
        "repository": {
          "type": "local",
          "directory": path.join(__dirname, '..', 'fixtures', 'repositories', 'local-file'),
@@ -40,15 +34,13 @@ vows.describe('haibu/repositories/local-file').addBatch(helpers.requireInit()).a
       "should be a valid repository": function (localFile) {
         assert.instanceOf(localFile, haibu.repository.Repository);
         assert.isFunction(localFile.init);
-        assert.isFunction(localFile.exists);
-        assert.isFunction(localFile.update);
         assert.isFunction(localFile.fetch);
       },
       "the fetch() method": {
         topic: function (localFile) {
           localFile.fetch(this.callback);
         },
-        "use the local filesystem": function (err, localFile) {
+        "should find the local app directory": function (err, localFile) {
           try {
             assert.isNotNull(fs.statSync(localFile));
           }
@@ -57,21 +49,11 @@ vows.describe('haibu/repositories/local-file').addBatch(helpers.requireInit()).a
             assert.isNull(ex);
           }
         }
-      }
-    }
-  }
-}).addBatch({
-  "When using haibu": {
-    "an instance of the LocalFile repository": {
-      topic: function () {
-        return haibu.repository.create(app);
-      },
-      "should be a valid repository": function (localFile) {
-        assert.instanceOf(localFile, haibu.repository.Repository);
       },
       "the init() method": {
         topic: function (localFile) {
           var self = this;
+          if (!(localFile instanceof haibu.repository.Repository)) return localFile;
           exec('rm -rf ' + path.join(localFile.appDir, '*'), function(err) {
             localFile.mkdir(function (err, created) {
               if (err) self.callback(err);

--- a/test/repositories/local-file-test.js
+++ b/test/repositories/local-file-test.js
@@ -8,6 +8,7 @@
 var assert = require('assert'),
     fs = require('fs'),
     path = require('path'),
+    exec = require('child_process').exec,
     eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
@@ -55,6 +56,30 @@ vows.describe('haibu/repositories/local-file').addBatch(helpers.requireInit()).a
             // If this operation fails, fail the test
             assert.isNull(ex);
           }
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using haibu": {
+    "an instance of the LocalFile repository": {
+      topic: function () {
+        return haibu.repository.create(app);
+      },
+      "should be a valid repository": function (localFile) {
+        assert.instanceOf(localFile, haibu.repository.Repository);
+      },
+      "the init() method": {
+        topic: function (localFile) {
+          var self = this;
+          exec('rm -rf ' + path.join(localFile.appDir, '*'), function(err) {
+            if (err) self.callback(err);
+            localFile.init(self.callback);
+          });
+        },
+        "should install to the specified location": function (err, success, files) {
+          assert.isNull(err);
+          assert.isArray(files);
         }
       }
     }

--- a/test/repositories/local-file-test.js
+++ b/test/repositories/local-file-test.js
@@ -37,7 +37,7 @@ vows.describe('haibu/repositories/local-file').addBatch(helpers.requireInit()).a
         return haibu.repository.create(app);
       },
       "should be a valid repository": function (localFile) {
-        assert.equal(haibu.repository.validate(localFile.app).valid, true);
+        assert.instanceOf(localFile, haibu.repository.Repository);
         assert.isFunction(localFile.init);
         assert.isFunction(localFile.exists);
         assert.isFunction(localFile.update);

--- a/test/repositories/npm-test.js
+++ b/test/repositories/npm-test.js
@@ -42,7 +42,7 @@ vows.describe('haibu/repositories/npm').addBatch(
   "When using haibu": {
     "an instance of the Npm repository": {
       "should be a valid repository": function () {
-        assert.equal(haibu.repository.validate(npm.app).valid, true);
+        assert.instanceOf(npm, haibu.repository.Repository);
         assert.isFunction(npm.init);
         assert.isFunction(npm.exists);
         assert.isFunction(npm.update);

--- a/test/repositories/npm-test.js
+++ b/test/repositories/npm-test.js
@@ -7,27 +7,17 @@
  
 var assert = require('assert'),
     path = require('path'),
-    eyes = require('eyes'),
+    exec = require('child_process').exec,
     vows = require('vows'),
     haibu = require('../../lib/haibu'),
-    Npm = require('../../lib/haibu/repositories/npm').Npm,
     helpers = require('./../helpers');
 
-var ipAddress = '127.0.0.1', 
-    port = 9000, npm,
-    app = {
-      "name": "test",
+var app = {
       "user": "marak",
-      "directories": {
-        "home": "hellonode"
-      },
+      "name": "test",
       "repository": {
-        "type": "zip",
-        "protocol": "http",
-        "url": "http://c0027507.cdn1.cloudfiles.rackspacecloud.com/hellonode.zip",
-      },
-      "dependencies": {
-        "translate": ">= 0.3.3"
+        "type": "npm",
+        "package": "hook.io-helloworld"
       },
       "scripts": {
         "start": "server.js"
@@ -35,33 +25,35 @@ var ipAddress = '127.0.0.1',
     };    
 
 vows.describe('haibu/repositories/npm').addBatch(
-  helpers.requireInit(function () {
-    npm = new Npm(app);
-  })
+  helpers.requireInit()
 ).addBatch({
   "When using haibu": {
     "an instance of the Npm repository": {
-      "should be a valid repository": function () {
+      topic: function () {
+        return haibu.repository.create(app);
+      },
+      "should be a valid repository": function (npm) {
         assert.instanceOf(npm, haibu.repository.Repository);
         assert.isFunction(npm.init);
-        assert.isFunction(npm.exists);
-        assert.isFunction(npm.update);
-      }
-    }
-  }
-}).addBatch({
-  "When using haibu": {
-    "an instance of the Npm repository": {
-      "the update() method": {
-        topic: function () {
-          npm.update(this.callback);
+        assert.isFunction(npm.installDependencies);
+      },
+      "the init() method": {
+        topic: function (npm) {
+          var self = this;
+          if (!(npm instanceof haibu.repository.Repository)) return npm;
+          exec('rm -rf ' + path.join(npm.appDir, '*'), function(err) {
+            npm.mkdir(function (err, created) {
+              if (err) self.callback(err);
+              npm.init(self.callback);
+            })
+          })
         },
-        "should reset the local files in the repository": function (err, updated, installed) {
+        "should install to the specified location": function (err, updated, installed) {
           assert.isNull(err);
           assert.isTrue(updated);
           assert.isArray(installed);
         }
-      },
+      }
     }
   }
 }).export(module);

--- a/test/repositories/remote-file-test.js
+++ b/test/repositories/remote-file-test.js
@@ -14,36 +14,26 @@ var assert = require('assert'),
     haibu = require('../../lib/haibu'),
     RemoteFile = require('../../lib/haibu/repositories/remote-file').RemoteFile;
 
-var ipAddress = '127.0.0.1', 
-    port = 9000, 
-    config = helpers.loadConfig(false) || {},
-    remoteFile,
-    app;
+var config = helpers.loadConfig(false) || {};
     
-cloudfilesApp = {
+var cloudfilesApp = {
   "name": "test",
   "user": "charlie",
-  "directories": {
-    "home": "hellonode"
-  },
   "repository": {
-    "auth": config.auth,
+    "type": "tar",
     "protocol": "cloudfiles",
+    "auth": config.auth,
     "container": "nodejitsu-apps",
-    "filename": "hellonode.tar.gz",
-    "type": "tar"
+    "filename": "hellonode.tar.gz"
   },
   "scripts": {
     "start": "server.js"
   }
 };
 
-httpApp = {
+var httpApp = {
   "name": "test",
   "user": "marak", 
-  "directories": {
-    "home": "hellonode"
-  },
   "repository": {
     "type": "tar",
     "protocol": "http",
@@ -80,8 +70,6 @@ if (!config.auth) {
       "an instance of the RemoteFile repository": {
         "should be a valid repository": function () {
           assert.isFunction(remoteFile.init);
-          assert.isFunction(remoteFile.exists);
-          assert.isFunction(remoteFile.update);
           assert.isFunction(remoteFile.fetchHttp);
           assert.isFunction(remoteFile.fetchCloudfiles);
         },

--- a/test/repositories/remote-file-test.js
+++ b/test/repositories/remote-file-test.js
@@ -16,13 +16,13 @@ var assert = require('assert'),
 
 var ipAddress = '127.0.0.1', 
     port = 9000, 
-    config = helpers.loadConfig(true) || {},
+    config = helpers.loadConfig(false) || {},
     remoteFile,
     app;
     
-app = {
+cloudfilesApp = {
   "name": "test",
-  "user": "marak",
+  "user": "charlie",
   "directories": {
     "home": "hellonode"
   },
@@ -38,43 +38,83 @@ app = {
   }
 };
 
-var suite = vows.describe('haibu/repositories/remote-file').addBatch(
-  helpers.requireInit(function () {
-    remoteFile = new RemoteFile(app);
-  })
-).addBatch({
-  "When using haibu": {
-    "an instance of the RemoteFile repository": {
-      "should be a valid repository": function () {
-        assert.isFunction(remoteFile.init);
-        assert.isFunction(remoteFile.exists);
-        assert.isFunction(remoteFile.update);
-        assert.isFunction(remoteFile.fetchHttp);
-        assert.isFunction(remoteFile.fetchCloudfiles);
-      },
-      "the fetchCloudfiles() method": {
-        topic: function () {
-          var options = {
-            container: 'nodejitsu-apps',
-            filename: 'hellonode.tar.gz'
-          };
-          
-          remoteFile.fetchCloudfiles(options, this.callback);
+httpApp = {
+  "name": "test",
+  "user": "marak", 
+  "directories": {
+    "home": "hellonode"
+  },
+  "repository": {
+    "type": "tar",
+    "protocol": "http",
+    "url": "http://c0027507.cdn1.cloudfiles.rackspacecloud.com/hellonode.tar.gz"
+  },
+  "scripts": {
+    "start": "server.js"
+  }
+};
+
+var suite = vows.describe('haibu/repositories/remote-file');
+
+// skip cloudfiles tests if no authentication available
+if (!config.auth) {
+  suite.addBatch({
+    "When using haibu": {
+      "Config file test/fixtures/test-config.json doesn't have valid data": {
+        "so skipping cloudfiles tests": function () {
+          assert.isNull(null);
+        }
+      }
+    }
+  });
+} else {
+  // cloudfiles remote tests
+  suite.addBatch(
+    helpers.requireInit(function () {
+      remoteFile = new RemoteFile(cloudfilesApp);
+    })
+  );
+
+  suite.addBatch({
+    "When using haibu": {
+      "an instance of the RemoteFile repository": {
+        "should be a valid repository": function () {
+          assert.isFunction(remoteFile.init);
+          assert.isFunction(remoteFile.exists);
+          assert.isFunction(remoteFile.update);
+          assert.isFunction(remoteFile.fetchHttp);
+          assert.isFunction(remoteFile.fetchCloudfiles);
         },
-        "should download the package to the correct local file": function (err, localFile) {
-          try {
-            assert.isNotNull(fs.statSync(localFile));
-            fs.unlinkSync(localFile);
-          }
-          catch (ex) {
-            // If this operation fails, fail the test
-            assert.isNull(ex);
+        "the fetchCloudfiles() method": {
+          topic: function () {
+            var options = {
+              container: 'nodejitsu-apps',
+              filename: 'hellonode.tar.gz'
+            };
+          
+            remoteFile.fetchCloudfiles(options, this.callback);
+          },
+          "should download the package to the correct local file": function (err, localFile) {
+            try {
+              assert.isNotNull(fs.statSync(localFile));
+              fs.unlinkSync(localFile);
+            }
+            catch (ex) {
+              // If this operation fails, fail the test
+              assert.isNull(ex);
+            }
           }
         }
       }
     }
-  }
-}).addBatch({
+  })
+}
+
+suite.addBatch(
+  helpers.requireInit(function () {
+    remoteFile = new RemoteFile(httpApp);
+  })
+).addBatch({
   "When using haibu": {
     "an instance of the RemoteFile repository": {
       "the fetchHttp() method": {
@@ -96,9 +136,7 @@ var suite = vows.describe('haibu/repositories/remote-file').addBatch(
   }
 });
 
-if (config.auth) {
-  //
-  // Export the suite to the test module
-  //
-  suite.export(module);
-}
+//
+// Export the suite to the test module
+//
+suite.export(module);

--- a/test/repositories/tar-test.js
+++ b/test/repositories/tar-test.js
@@ -71,7 +71,7 @@ var suite = vows.describe('haibu/repositories/tar').addBatch(helpers.requireInit
         return haibu.repository.create(app);
       },
       "should be a valid repository": function (tar) {
-        assert.equal(haibu.repository.validate(tar.app).valid, true);
+        assert.instanceOf(tar, haibu.repository.Repository);
         assert.isFunction(tar.init);
         assert.isFunction(tar.exists);
         assert.isFunction(tar.update);

--- a/test/repositories/tar-test.js
+++ b/test/repositories/tar-test.js
@@ -63,7 +63,6 @@ var suite = vows.describe('haibu/repositories/tar').addBatch(helpers.requireInit
         return {};
       },
       "so skipping cloudfiles tests": function(obj) {
-        assert.isNull(null);
       }
     };
   } else {

--- a/test/repositories/tar-test.js
+++ b/test/repositories/tar-test.js
@@ -7,6 +7,7 @@
 
 var assert = require('assert'),
     path = require('path'),
+    exec = require('child_process').exec,
     eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
@@ -47,7 +48,10 @@ cloudfilesApp = {
 };
 
 // Create the vows test suite
-var suite = vows.describe('haibu/repositories/tar').addBatch(helpers.requireInit());
+var suite = vows.describe('haibu/repositories/tar').addBatch(
+  helpers.requireInit()
+);
+
 //
 // Iterate over the two remote types we wish to execute
 // identical tests for.
@@ -81,9 +85,10 @@ var suite = vows.describe('haibu/repositories/tar').addBatch(helpers.requireInit
       "the init() method": {
         topic: function (tar) {
           var self = this;
-          tar.bootstrap(function () {
+          exec('rm -rf ' + path.join(tar.appDir, '*'), function(err) {
+            if (err) self.callback(err);
             tar.init(self.callback);
-          })
+          });
         },
         "should untar to the specified location": function (err, success, files) {
           assert.isNull(err);

--- a/test/repositories/tar-test.js
+++ b/test/repositories/tar-test.js
@@ -13,13 +13,9 @@ var assert = require('assert'),
     helpers = require('../helpers'),
     haibu = require('../../lib/haibu');
 
-var ipAddress = '127.0.0.1', 
-    port = 9000, 
-    config = helpers.loadConfig(false) || {},
-    cloudfilesApp,
-    httpApp;
+var config = helpers.loadConfig(false) || {};
     
-httpApp = {
+var httpApp = {
   "name": "test",
   "user": "marak", 
   "repository": {
@@ -32,7 +28,7 @@ httpApp = {
   }
 };
 
-cloudfilesApp = {
+var cloudfilesApp = {
   "name": "test",
   "user": "charlie",
   "repository": {
@@ -77,14 +73,13 @@ var suite = vows.describe('haibu/repositories/tar').addBatch(
       "should be a valid repository": function (tar) {
         assert.instanceOf(tar, haibu.repository.Repository);
         assert.isFunction(tar.init);
-        assert.isFunction(tar.exists);
-        assert.isFunction(tar.update);
         assert.isFunction(tar.fetchHttp);
         assert.isFunction(tar.fetchCloudfiles);
       },
       "the init() method": {
         topic: function (tar) {
           var self = this;
+          if (!(tar instanceof haibu.repository.Repository)) return tar;
           exec('rm -rf ' + path.join(tar.appDir, '*'), function(err) {
             tar.mkdir(function (err, created) {
               if (err) self.callback(err);

--- a/test/repositories/tar-test.js
+++ b/test/repositories/tar-test.js
@@ -86,8 +86,10 @@ var suite = vows.describe('haibu/repositories/tar').addBatch(
         topic: function (tar) {
           var self = this;
           exec('rm -rf ' + path.join(tar.appDir, '*'), function(err) {
-            if (err) self.callback(err);
-            tar.init(self.callback);
+            tar.mkdir(function (err, created) {
+              if (err) self.callback(err);
+              tar.init(self.callback);
+            });
           });
         },
         "should untar to the specified location": function (err, success, files) {

--- a/test/repositories/zip-test.js
+++ b/test/repositories/zip-test.js
@@ -13,13 +13,9 @@ var assert = require('assert'),
     helpers = require('../helpers'),
     haibu = require('../../lib/haibu');
 
-var ipAddress = '127.0.0.1',
-    port = 9000,
-    config = helpers.loadConfig(false) || {},
-    cloudfilesApp,
-    httpApp;
+var config = helpers.loadConfig(false) || {};
     
-httpApp = {
+var httpApp = {
   "name": "test",
   "user": "marak",
   "repository": {
@@ -32,7 +28,7 @@ httpApp = {
   }
 };
 
-cloudfilesApp = {
+var cloudfilesApp = {
   "name": "test",
   "user": "charlie",
   "repository": {
@@ -77,14 +73,13 @@ var suite = vows.describe('haibu/repositories/zip').addBatch(
       "should be a valid repository": function (zip) {
         assert.instanceOf(zip, haibu.repository.Repository);
         assert.isFunction(zip.init);
-        assert.isFunction(zip.exists);
-        assert.isFunction(zip.update);
         assert.isFunction(zip.fetchHttp);
         assert.isFunction(zip.fetchCloudfiles);
       },
       "the init() method": {
         topic: function (zip) {
           var self = this;
+          if (!(zip instanceof haibu.repository.Repository)) return zip;
           exec('rm -rf ' + path.join(zip.appDir, '*'), function(err) {
             zip.mkdir(function (err, created) {
               if (err) self.callback(err);

--- a/test/repositories/zip-test.js
+++ b/test/repositories/zip-test.js
@@ -74,7 +74,7 @@ var suite = vows.describe('haibu/repositories/zip').addBatch(
         return haibu.repository.create(app);
       },
       "should be a valid repository": function (zip) {
-        assert.equal(haibu.repository.validate(zip.app).valid, true);
+        assert.instanceOf(zip, haibu.repository.Repository);
         assert.isFunction(zip.init);
         assert.isFunction(zip.exists);
         assert.isFunction(zip.update);

--- a/test/repositories/zip-test.js
+++ b/test/repositories/zip-test.js
@@ -86,8 +86,10 @@ var suite = vows.describe('haibu/repositories/zip').addBatch(
         topic: function (zip) {
           var self = this;
           exec('rm -rf ' + path.join(zip.appDir, '*'), function(err) {
-            if (err) self.callback(err);
-            zip.init(self.callback);
+            zip.mkdir(function (err, created) {
+              if (err) self.callback(err);
+              zip.init(self.callback);
+            });
           });
         },
         "should unzip to the specified location": function (err, success, files) {

--- a/test/repositories/zip-test.js
+++ b/test/repositories/zip-test.js
@@ -7,6 +7,7 @@
 
 var assert = require('assert'),
     path = require('path'),
+    exec = require('child_process').exec,
     eyes = require('eyes'),
     vows = require('vows'),
     helpers = require('../helpers'),
@@ -83,7 +84,11 @@ var suite = vows.describe('haibu/repositories/zip').addBatch(
       },
       "the init() method": {
         topic: function (zip) {
-          zip.init(this.callback);
+          var self = this;
+          exec('rm -rf ' + path.join(zip.appDir, '*'), function(err) {
+            if (err) self.callback(err);
+            zip.init(self.callback);
+          });
         },
         "should unzip to the specified location": function (err, success, files) {
           assert.isNull(err);

--- a/test/repositories/zip-test.js
+++ b/test/repositories/zip-test.js
@@ -66,7 +66,6 @@ var suite = vows.describe('haibu/repositories/zip').addBatch(
         return {};
       },
       "so skipping cloudfiles tests": function(obj) {
-        assert.isNull(null);
       }
     };
   } else {


### PR DESCRIPTION
Wanted to implement my own repository type and found out that it was difficult to add one so I added a repository class store with accompanying add, remove and list functions. 

Working on it I also implemented App config checking to be use from all repository classes and I also found some `throw` statements  (instead of using `callback(err)`) that would break haibu if there wasn't a global error handling function.

BTW also added a vows test file and changed the existing tests for the changed error returns.

Hope this is clean enough to be pushed ahead!!

Thanks,

Sander
