### PR TITLE
Two fixes for minor bugs in spawn function

### DIFF
--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -58,15 +58,20 @@ Spawner.prototype.trySpawn = function (app, callback) {
 
 //
 // ### function spawn (app, callback)
-// #### @app {App} Application to attempt to spawn on this server.
+// #### @repo {Repository} App code repository to spawn from on this server.
 // #### @callback {function} Continuation passed to respond to.
-// spawns the appropriate carapace for an Application and bootstraps with the events listed
+// spawns the appropriate carapace for an Application repository and bootstraps with the events listed
 //
 Spawner.prototype.spawn = function spawn (repo, callback) {
+  if (!(repo instanceof haibu.repository.Repository)) {
+    return callback(new Error('Error spawning drone: no repository defined'));
+  }
+  
   var self = this,
-      app  = repo instanceof haibu.repository.Repository ? repo.app : app,
+      app  = repo.app,
       meta = { app: app.name, user: app.user },
       script = repo.startScript,
+      result,
       responded = false,
       stderr = [],
       foreverOptions,


### PR DESCRIPTION
Found two minor bugs in the spawn function and fixed it..

(1) app is no argument anymore so check repo type
(2) Missing 'result' var definition
