### PR TITLE
add streaming logs via little-big-events

### DIFF
--- a/lib/haibu.js
+++ b/lib/haibu.js
@@ -6,11 +6,26 @@
  */
 
 var fs = require('fs'),
-    events = require('events'),
+    events = require('little-big-events'),
     path = require('path'),
     hookio = require('hook.io');
 
-var haibu = module.exports = new events.EventEmitter();
+function tryLoadCacheSync () {
+  cachePath = path.join(__dirname, '..', 'config', 'cache.json');
+  try {
+    return JSON.parse(fs.readFileSync(cachePath))    
+  } catch (err) {
+    return {}
+  }
+}
+
+var _config = tryLoadCacheSync ();
+
+_config.type = 'redis'
+//this will emit all haibu events to redis, 
+//and also opens the door to listening to events in other parts of the stack.
+
+var haibu = module.exports = new events.EventEmitter(_config);
 
 //
 // Expose version through `pkginfo`.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pkginfo": "0.2.x",
     "rimraf": "1.0.x",
     "request": "2.1.x",
+    "little-big-events": "0.0.x",
     "winston": "0.5.x >=0.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
this adds streaming logs via redis pubsub.

start haibu, 

then in redis-cli

PSUBSCRIBE *

you will get a stream of all haibu events.
by refactoring the haibu messages to a form like user:app:xxx:yyy 
then it will be easy to add user logs, but it will also be easy to add user logs by enabling a 
stream/socket.io interface to the events.

also, we will be able to make a nodejitsu dashboard that we can easily monitor any app or collection of apps, or haibus, etc. to montior our cluster -- and measure user engagement.

I've done it this way, because it's simple, and also leaves the door open to sending events the other way.

here is a draft of what the http interface will look like: https://gist.github.com/b982afbbe66d67687be6
