### PR TITLE
Capture multiple ports

### DIFF
--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -157,6 +157,7 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
       script = repo.startScript,
       result,
       responded = false,
+      timeout = null,
       stderr = [],
       stdout = [],
       options = [],
@@ -301,20 +302,35 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
     //
     function onCarapacePort (info) {
       if (!responded && info && info.event === 'port') {
-        responded = true;
-        result.socket = {
-          host: self.host,
-          port: info.data.port
-        };
+        if (result.socket) {
+          if( typeof result.port != 'object' ) {
+            result.socket.port = [result.socket.port];
+          }
+          
+          result.socket.port.push( info.data.port )
+        }
+        else {
+          result.socket = {
+            host: self.host,
+            port: info.data.port
+          };
+        }
         
-        drone.minUptime = 0;
-        callback(null, result);
-
         //
-        // Remove listeners to related events
+        // Little delay so we can capture all ports
         //
-        drone.removeListener('exit', onExit);
-        drone.removeListener('error', onError);
+        if (!timeout)
+          timeout = setTimeout(function(){
+            responded = true;
+            drone.minUptime = 0;
+            callback(null, result);
+  
+            //
+            // Remove listeners to related events
+            //
+            drone.removeListener('exit', onExit);
+            drone.removeListener('error', onError);
+          }, 100);
       }
     }
 

--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -315,6 +315,22 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
             port: info.data.port
           };
         }
+        
+        //
+        // Little delay so we can capture all ports
+        //
+        if (!timeout)
+          timeout = setTimeout(function(){
+            responded = true;
+            drone.minUptime = 0;
+            callback(null, result);
+  
+            //
+            // Remove listeners to related events
+            //
+            drone.removeListener('exit', onExit);
+            drone.removeListener('error', onError);
+          }, 100);
       }
     }
 
@@ -329,22 +345,6 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
         process: monitor.child,
         data: data
       };
-      
-      //
-      // Little delay so we can capture all ports
-      // and run workers without ports too
-      //
-      timeout = setTimeout(function(){
-        responded = true;
-        drone.minUptime = 0;
-        callback(null, result);
-
-        //
-        // Remove listeners to related events
-        //
-        drone.removeListener('exit', onExit);
-        drone.removeListener('error', onError);
-      }, 100);
     }
 
     //

--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -315,22 +315,6 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
             port: info.data.port
           };
         }
-        
-        //
-        // Little delay so we can capture all ports
-        //
-        if (!timeout)
-          timeout = setTimeout(function(){
-            responded = true;
-            drone.minUptime = 0;
-            callback(null, result);
-  
-            //
-            // Remove listeners to related events
-            //
-            drone.removeListener('exit', onExit);
-            drone.removeListener('error', onError);
-          }, 100);
       }
     }
 
@@ -345,6 +329,22 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
         process: monitor.child,
         data: data
       };
+      
+      //
+      // Little delay so we can capture all ports
+      // and run workers without ports too
+      //
+      timeout = setTimeout(function(){
+        responded = true;
+        drone.minUptime = 0;
+        callback(null, result);
+
+        //
+        // Remove listeners to related events
+        //
+        drone.removeListener('exit', onExit);
+        drone.removeListener('error', onError);
+      }, 100);
     }
 
     //


### PR DESCRIPTION
Currently Haibu-carapace is able to find multiple ports, but Haibu itself doesn't do anything with it. It would be handy if it does, because this way you can inform the user, log it or open these ports in firewalls dynamic too.

It is common to use one port for a full Application, but I got a rare case where multiple listeners are created for different situations in a single process, it was there for kinda strange Haibu reacted with a single port. 

The attached code is my current implementation. I'm still not sure about the little timeout, but nextTick wasn't a solution in this case.
