### PR TITLE
[minor] Make the error message for "no matching engines found" more human-readable/helpful

### DIFF
--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -32,7 +32,12 @@ haibu.getSpawnOptions = function getSpawnOptions (app) {
     }
     version = semver.maxSatisfying(nodeVersions, engine);
     if (!version) {
-      var err = new Error('Error spawning drone: no matching engine found');
+      var err = new Error([
+        'Haibu could not find a node.js version satisfying specified',
+        'node.js engine `' + String(engine) + '`. Try specifying a different '
+          + 'version of node.js',
+        'in your package.json, such as `0.6.x`.'
+      ].join('\n'));
       err.blame = {
         type: 'user',
         message: 'Repository configuration'


### PR DESCRIPTION
The new error should look something like this in the context of jitsu:

```
error: Error: Haibu could not find a node.js version satisfying specified
error: node.js engine `0.8.x`. Try specifying a different version of node.js
error: in your package.json, such as `0.6.x`.
```
