### PR TITLE
[api] Stop the drone when port isn't open after some timeout

### DIFF
--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -163,6 +163,7 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
       options = ['--plugin', 'net'],
       foreverOptions,
       carapaceBin,
+      timeout,
       error,
       drone;
 
@@ -293,6 +294,7 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
         //
         drone.removeListener('exit', onExit);
         drone.removeListener('message', onCarapacePort);
+        clearTimeout(timeout);
       }
     }
 
@@ -322,6 +324,7 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
         //
         drone.removeListener('exit', onExit);
         drone.removeListener('error', onError);
+        clearTimeout(timeout);
       }
     }
 
@@ -380,7 +383,23 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
         //
         drone.removeListener('error', onError);
         drone.removeListener('message', onCarapacePort);
+        clearTimeout(timeout);
       }
+    }
+
+    function onTimeout() {
+      drone.removeListener('exit', onExit);
+
+      drone.stop();
+      error = new Error('Error spawning drone');
+      error.blame = {
+        type: 'user',
+        message: 'Script took too long to listen on a socket'
+      };
+      error.stdout = stdout.join('\n');
+      error.stderr = stderr.join('\n');
+
+      callback(error);
     }
 
     //
@@ -393,6 +412,9 @@ Spawner.prototype.spawn = function spawn (repo, callback) {
     drone.once('start', onChildStart);
     drone.on('restart', onChildRestart);
     drone.on('message', onCarapacePort);
+
+    timeout = setTimeout(onTimeout, haibu.config.get('portTimeout') || 5000);
+
     drone.start();
   });
 };


### PR DESCRIPTION
Failing to do so causes zombie processes to be created. Haibu instance
loses tracks of processes which were started but failed to listen on a
socket and doesn't kill them.
