### PR TITLE
Fix uncaught exception.

### DIFF
--- a/lib/haibu/repositories/git.js
+++ b/lib/haibu/repositories/git.js
@@ -70,7 +70,7 @@ Git.prototype.init = function (callback) {
       type: 'user',
       message: 'Repository configuration present but provides invalid Git URL'
     };
-    return callback();
+    return callback(err);
   }
 
   // Set the home directory of the app managed by this instance.


### PR DESCRIPTION
This uncaught exception in the git-url validation was making the app crash. 
Just doing something with the error-object resolves the issue (the exception is now caught).
