### PR TITLE
Battle hardening

### DIFF
--- a/lib/haibu/core/spawner.js
+++ b/lib/haibu/core/spawner.js
@@ -32,12 +32,7 @@ haibu.getSpawnOptions = function getSpawnOptions (app) {
     }
     version = semver.maxSatisfying(nodeVersions, engine);
     if (!version) {
-      var err = new Error([
-        'Haibu could not find a node.js version satisfying specified',
-        'node.js engine `' + String(engine) + '`. Try specifying a different '
-          + 'version of node.js',
-        'in your package.json, such as `0.8.x`.'
-      ].join('\n'));
+      var err = new Error('Error spawning drone: no matching engine found');
       err.blame = {
         type: 'user',
         message: 'Repository configuration'

--- a/lib/haibu/repositories/repository.js
+++ b/lib/haibu/repositories/repository.js
@@ -94,7 +94,7 @@ Repository.prototype.installDependencies = function (callback) {
       }
     }
 
-    return noNpm !== false
+    return noNpm !== true
       ? haibu.common.npm.install(self.homeDir, self.app, callback)
       : callback(null, self.app.dependencies);
   });

--- a/lib/haibu/repositories/repository.js
+++ b/lib/haibu/repositories/repository.js
@@ -77,7 +77,8 @@ Repository.prototype.validate = function (keys, app) {
 // with this repository instance on this system.
 //
 Repository.prototype.installDependencies = function (callback) {
-  var self = this;
+  var noNpm = haibu.config.get('no-npm'),
+      self  = this;
 
   fs.readFile(path.join(this.homeDir, 'package.json'), function (err, data) {
     if (!err) {
@@ -93,7 +94,9 @@ Repository.prototype.installDependencies = function (callback) {
       }
     }
 
-    haibu.common.npm.install(self.homeDir, self.app, callback);
+    return noNpm !== false
+      ? haibu.common.npm.install(self.homeDir, self.app, callback)
+      : callback(null, self.app.dependencies);
   });
 };
 

--- a/lib/haibu/repositories/tar.js
+++ b/lib/haibu/repositories/tar.js
@@ -7,8 +7,6 @@
 
 var fs = require('fs'),
     util = require('util'),
-    zlib = require('zlib'),
-    tar = require('tar'),
     haibu = require('../../haibu'),
     RemoteFile = require('./remote-file').RemoteFile;
 
@@ -49,14 +47,16 @@ Tar.prototype.init = function (callback) {
       return callback(err);
     }
 
-    var files = [];
+    var child = require('child_process').spawn('tar', ['-C', self.appDir, '-xzf', '-']),
+        files = [];
 
-    var extractor = new tar.Extract({ path: self.appDir });
-    extractor.on('entry', function (entry) {
-      files.push(entry.path);
-    });
+    fs.createReadStream(packageFile).pipe(child.stdin);
 
-    fs.createReadStream(packageFile).pipe(zlib.Gunzip()).pipe(extractor).on('end', function () {
+    child.on('exit', function (statusCode) {
+      if (statusCode) {
+        return callback(new Error('tar exited with code: ' + statusCode));
+      }
+
       self.stat(function (err, exists) {
         if (err) {
           return callback(err);


### PR DESCRIPTION
1. Prefer spawning `tar` processes over using `var tar = require('tar');` (memory consumption).
2. Allow for `npm` to be shut-off completely with `haibu.config.set('no-npm', true);`
3. Fix some opaque error.
